### PR TITLE
Link site location to Google Maps

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ author:
   name             : "Dr. Artem Shelmanov"
   #pronouns         : # example: "she/her"  
   bio              : "Sr. Research Scientist @ <a href='https://mbzuai.ac.ae/'>MBZUAI</a>"
-  location         : "Abu Dhabi, UAE"
+  location         : "<a href='https://maps.app.goo.gl/uFErwJwPkSqTUbyz9'>Abu Dhabi, UAE</a>"
   #employer         : "Mohamed bin Zayed University of Artificial Intelligence: MBZUAI"
   uri              : # URL
   email            : "artemshelmanov@gmail.com" 

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -11,3 +11,5 @@ I am an AI researcher passionate about advancing natural language processing (NL
 
 I lead a research team that develops robust uncertainty quantification (UQ) techniques to efficiently tackle LLM hallucinations. The team has created the most comprehensive UQ library for LLMs: [LM-Polygraph](https://github.com/IINemo/lm-polygraph).
 Our research aims to increase the applicability of AI technologies in safety-critical areas, such as healthcare and finance.
+
+Based in [Abu Dhabi, UAE](https://maps.app.goo.gl/uFErwJwPkSqTUbyz9), I welcome collaborations and discussions on these topics.


### PR DESCRIPTION
## Summary
- Link Abu Dhabi location to provided Google Maps URL in site configuration
- Highlight Abu Dhabi home base with a Google Maps link on the landing page

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_689c25b483cc8329bed358ef9c2e6f40